### PR TITLE
Remove paths that can cause unnecessary errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,8 +44,6 @@ func (c *Config) ReadConfig(configPath string) {
 	c.v.SetConfigType("toml")
 
 	// Check for overriding config files
-	c.v.AddConfigPath("$GOPATH/src/sprawl/")
-	c.v.AddConfigPath("$GOPATH/src/github.com/eqlabs/sprawl/")
 	c.v.AddConfigPath(".")
 
 	// Check for user submitted config path


### PR DESCRIPTION
These paths don't work well for me. Might as well remove them as they don't offer any real value.

```
$ go run main.go
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/spf13/viper.absPathify(0xe63458, 0x13, 0x0, 0x181d920)
        C:/Users/Sloth/go/pkg/mod/github.com/spf13/viper@v1.4.0/util.go:100 +0x450
github.com/spf13/viper.(*Viper).AddConfigPath(0xc0000bd200, 0xe63458, 0x13)
        C:/Users/Sloth/go/pkg/mod/github.com/spf13/viper@v1.4.0/viper.go:413 +0x69
github.com/eqlabs/sprawl/config.(*Config).ReadConfig(0xc0000ac220, 0xe616ec, 0x11)
        C:/Users/Sloth/Videos/sprawl/config/config.go:47 +0x3d1
github.com/eqlabs/sprawl/app.init.0()
        C:/Users/Sloth/Videos/sprawl/app/app.go:29 +0x6f
exit status 2

```